### PR TITLE
Update Expo SDK and React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@expo-google-fonts/pacifico": "^0.2.3",
-    "expo": "~51.0.14",
+    "expo": "~51.0.28",
     "expo-build-properties": "^0.12.3",
     "expo-constants": "^16.0.2",
     "expo-font": "^12.0.7",
@@ -21,7 +21,7 @@
     "expo-router": "^3.5.16",
     "expo-status-bar": "~1.12.1",
     "react": "18.2.0",
-    "react-native": "0.74.2",
+    "react-native": "0.75.0",
     "react-native-safe-area-context": "^4.10.5",
     "react-native-screens": "^3.32.0"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react": "18.2.0",
     "react-native": "0.75.0",
     "react-native-safe-area-context": "^4.10.5",
-    "react-native-screens": "^3.32.0"
+    "react-native-screens": "~3.34.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
- React Native 0.75 was released 14 Aug 2024 https://reactnative.dev/blog/2024/08/12/release-0.75
- Expo SDK 51 already supports it https://expo.dev/changelog/2024/08-14-react-native-0.75

@ProchaLu you can go ahead and update the pnpm lockfile and test the app with these new versions

if it doesn't work out of the box or there are errors, there may be some hints in the Expo changelog post linked above